### PR TITLE
fix: move cart logic to HOC

### DIFF
--- a/client/components/AllProducts.js
+++ b/client/components/AllProducts.js
@@ -4,59 +4,10 @@ import {Link} from 'react-router-dom'
 import {fetchAllProducts} from '../store/products'
 import ProductCard from './ProductCard'
 import Cart from './Cart'
-import {fetchMergePastAndGuestCarts} from '../store/cart'
-
-// imperative reduceCart
-// takes in an orders array
-// and outputs a cart: { productId : quantity ... }
-const reduceOrdersToGetPastCart = (order = {products: []}) => {
-  let res = {}
-  const {products} = order
-
-  // if no products, return empty object ( {} )
-  if (!products.length) return {}
-
-  products.forEach(product => {
-    const cartItem = {
-      [product.ProductOrder.productId]: product.ProductOrder.quantity
-    }
-    res = {...res, ...cartItem}
-  })
-  return res
-}
 
 class AllProducts extends React.Component {
-  getUserCart() {
-    const unfulfilledOrder = this.props.user.orders.filter(
-      order => !order.date
-    )[0]
-    const pastCart = reduceOrdersToGetPastCart(unfulfilledOrder)
-    this.props.loadCart(pastCart)
-  }
-
   componentDidMount() {
     this.props.getProducts()
-
-    // if we're coming directly from logging in
-    // we WILL have access to user.id in componentDidMount
-    // so we need to make the same call to getUserCart()
-    if (this.props.user.id) this.getUserCart()
-
-    // here we call loadCart with no pastCart
-    // so that if user is NOT logged in
-    // they still get their guest cart from localStorage
-    this.props.loadCart({})
-  }
-
-  // user is not available in componentDidMount
-  // so we load the user's pastCart, which is an unfulfilledOrder
-  // here in componentDidMount
-  // and merge it in the redux store with this.props.loadCart
-  // which dispatches the merge pastCart and guestCart
-  // where guestCart is localStorage.getItem('cart') || {}
-
-  componentDidUpdate(prevProps) {
-    if (!prevProps.user.id && this.props.user.id) this.getUserCart()
   }
 
   render() {
@@ -93,17 +44,7 @@ const mapState = state => ({
 })
 
 const mapDispatch = dispatch => ({
-  getProducts: () => dispatch(fetchAllProducts()),
-  loadCart: pastCart => {
-    // here, we load a potential cart from localStorage
-    // so that guest users and users alike can persist an unfulfilled order
-    // -- if cart does not exist on localStorage the call returns null,
-    // so we check its truthiness and set it equal to an empty object
-    // if there is no cart!
-
-    let cartFromLocalStorage = JSON.parse(localStorage.getItem('cart')) || {}
-    dispatch(fetchMergePastAndGuestCarts(pastCart, cartFromLocalStorage))
-  }
+  getProducts: () => dispatch(fetchAllProducts())
 })
 
 export default connect(mapState, mapDispatch)(AllProducts)

--- a/client/components/helperFunctions.js
+++ b/client/components/helperFunctions.js
@@ -9,3 +9,22 @@ export function formatPrice(price) {
   const formattedPrice = priceArray.join('')
   return `$${formattedPrice}`
 }
+
+// imperative reduceCart
+// takes in an orders array
+// and outputs a cart: { productId : quantity ... }
+export const reduceOrdersToGetPastCart = (order = {products: []}) => {
+  let res = {}
+  const {products} = order
+
+  // if no products, return empty object ( {} )
+  if (!products.length) return {}
+
+  products.forEach(product => {
+    const cartItem = {
+      [product.ProductOrder.productId]: product.ProductOrder.quantity
+    }
+    res = {...res, ...cartItem}
+  })
+  return res
+}

--- a/client/routes.js
+++ b/client/routes.js
@@ -10,13 +10,38 @@ import {
   UserProfile
 } from './components'
 import {me} from './store'
+import {reduceOrdersToGetPastCart} from './components/helperFunctions'
+import {fetchMergePastAndGuestCarts} from './store/cart'
 
 /**
  * COMPONENT
  */
 class Routes extends Component {
+  getUserCart() {
+    const unfulfilledOrder = this.props.user.orders.filter(
+      order => !order.date
+    )[0]
+    const pastCart = reduceOrdersToGetPastCart(unfulfilledOrder)
+    this.props.loadCart(pastCart)
+  }
+
   componentDidMount() {
     this.props.loadInitialData()
+    // if we're coming directly from logging in
+    // we WILL have access to user.id in componentDidMount
+    // so we need to make the same call to getUserCart()
+    if (this.props.user.id) this.getUserCart()
+
+    // here we call loadCart with no pastCart
+    // so that if user is NOT logged in
+    // they still get their guest cart from localStorage
+    this.props.loadCart({})
+  }
+
+  // user is not immediately available in componentDidMount
+  // so we load the user's pastCart in componentDidUpdate
+  componentDidUpdate(prevProps) {
+    if (!prevProps.user.id && this.props.user.id) this.getUserCart()
   }
 
   render() {
@@ -42,17 +67,21 @@ const mapState = state => {
   return {
     // Being 'logged in' for our purposes will be defined has having a state.user that has a truthy id.
     // Otherwise, state.user will be an empty object, and state.user.id will be falsey
+    user: state.user,
     isLoggedIn: !!state.user.id
   }
 }
 
-const mapDispatch = dispatch => {
-  return {
-    loadInitialData() {
-      dispatch(me())
-    }
+const mapDispatch = dispatch => ({
+  loadInitialData: () => dispatch(me()),
+
+  // load guestCart from localStorage and pass along with pastCart
+  // to merge the two in the redux store
+  loadCart: pastCart => {
+    let cartFromLocalStorage = JSON.parse(localStorage.getItem('cart')) || {}
+    dispatch(fetchMergePastAndGuestCarts(pastCart, cartFromLocalStorage))
   }
-}
+})
 
 // The `withRouter` wrapper makes sure that updates are not blocked
 // when the url changes
@@ -62,6 +91,5 @@ export default withRouter(connect(mapState, mapDispatch)(Routes))
  * PROP TYPES
  */
 Routes.propTypes = {
-  loadInitialData: PropTypes.func.isRequired,
-  isLoggedIn: PropTypes.bool.isRequired
+  loadInitialData: PropTypes.func.isRequired
 }


### PR DESCRIPTION
this PR moves the cart logic into the ROUTES component so that singleProduct and allProduct components have access to cart updates, allowing cart to be consistent across views

note that cart is not yet updating db, so all cart changes are persisted locally but hard refresh will reset cart to initial db value + localStorage value