### PR TITLE
bugfix: change order of state spread when merging guest and user cart…

### DIFF
--- a/client/store/cart.js
+++ b/client/store/cart.js
@@ -86,10 +86,19 @@ export default (state = initState, action) => {
       return newCart
     }
     case MERGE_GUEST_AND_PAST_CARTS: {
+      // TODO
+      // here, we need to know whether user
+      // has logged in from a previous guestState
+      // where a guest cart has been created
+      // so we can reverse the order of the spreads
+      // and spread present cartFromLocalStorage
+      // OVER pastCart
+      // for now, this defaults to pastCart over localState
+      // so that db changes persist across browsers and devices
       const newCart = {
         ...state,
-        ...action.pastCart,
-        ...action.cartFromLocalStorage
+        ...action.cartFromLocalStorage,
+        ...action.pastCart
       }
       localStorage.setItem('cart', JSON.stringify(newCart))
       return newCart

--- a/server/api/carts.js
+++ b/server/api/carts.js
@@ -34,7 +34,7 @@ router.put('/:userId', isAdminOrUser, async (req, res, next) => {
 
     // update the ProductOrder instance
     const [
-      productToBeUpdatedInCart,
+      productOrderToBeUpdated,
       wasCreated
     ] = await ProductOrder.findOrCreate({
       where: {
@@ -44,15 +44,15 @@ router.put('/:userId', isAdminOrUser, async (req, res, next) => {
     })
 
     // if quantity === 0 then destroy the ProductOrder instance
-    if (quantity === 0) await productToBeUpdatedInCart.destroy()
+    if (quantity === 0) await productOrderToBeUpdated.destroy()
 
     // if product wasCreated return status 201
-    if (wasCreated) res.sendStatus(201)
+    if (wasCreated) return res.sendStatus(201)
 
-    // otherwise, product already existed
-    // so update the quantity and save the instance
-    productToBeUpdatedInCart.quantity = quantity
-    await productToBeUpdatedInCart.save()
+    // otherwise, we need to update the quantity of productOrderToBeUpdated
+    productOrderToBeUpdated.quantity = quantity
+    await productOrderToBeUpdated.save()
+
     res.sendStatus(201)
   } catch (err) {
     next(err)


### PR DESCRIPTION
this PR fixes a bug in the cart
before, localState was spread OVER past state,
which meant that user changes weren't persisted across
browsers / devices, since localStorage on the other browser
would overwrite the database change when it was pulled in